### PR TITLE
Updated demo with slider and support for latest 'matplotlib'.

### DIFF
--- a/bpypolyskel/bpypolyskel.py
+++ b/bpypolyskel/bpypolyskel.py
@@ -888,17 +888,17 @@ def polygonize(verts, firstVertIndex, numVerts, holesInfo=None, height=0., tan=0
     ----------
     verts:              A list of vertices. Vertices that define the outer contour of the footprint polygon are
                         located in a continuous block of the verts list, starting at the index firstVertIndex.
-                        Each vertex is an instance of mathutils.Vector with 3 coordinates x, y and z. The
+                        Each vertex is an instance of `mathutils.Vector` with 3 coordinates x, y and z. The
                         z-coordinate must be the same for all vertices of the polygon.
 
-                        The outer contour of the footprint polygon contains numVerts vertices in counterclockwise
-                        order, in its block in verts.
+                        The outer contour of the footprint polygon contains `numVerts` vertices in counterclockwise
+                        order, in its block in `verts`.
 
-                        Vertices that define eventual holes are also located in verts. Every hole takes its continuous
+                        Vertices that define eventual holes are also located in `verts`. Every hole takes its continuous
                         block. The start index and the length of every hole block are described by the argument
-                        holesInfo. See there.
+                        `holesInfo`. See there.
 
-                        The list of vertices verts gets extended by polygonize(). The new nodes of the straight
+                        The list of vertices verts gets extended by `polygonize()`. The new nodes of the straight
                         skeleton are appended at the end of the list.
 
     firstVertIndex: 	The first index of vertices of the polygon index in the verts list that defines the footprint polygon.
@@ -907,53 +907,53 @@ def polygonize(verts, firstVertIndex, numVerts, holesInfo=None, height=0., tan=0
                         contour of the footprint.
 
     holesInfo:          If the footprint polygon contains holes, their position and length in the verts list are
-                        described by this argument. holesInfo is a list of tuples, one for every hole. The first
-                        element in every tuple is the start index of the hole's vertices in verts and the second
+                        described by this argument. `holesInfo` is a list of tuples, one for every hole. The first
+                        element in every tuple is the start index of the hole's vertices in `verts` and the second
                         element is the number of its vertices.
 
                         The default value of holesInfo is None, which means that there are no holes.
 
-    height: 	        The maximum height of the hipped roof to be generated. If both height and tan are equal
-                        to zero, flat faces are generated. height takes precedence over tan if both have a non-zero
-                        value. The default value of height is 0.0.
+    height: 	        The maximum height of the hipped roof to be generated. If both `height` and `tan` are equal
+                        to zero, flat faces are generated. `height` takes precedence over `tan` if both have a non-zero
+                        value. The default value of `height` is 0.0.
 
     tan:                In many cases it's desirable to deal with the roof pitch angle instead of the maximum roof
-                        height. The tangent tan of the roof pitch angle can be supplied for that case. If both height
-                        and tan are equal to zero, flat faces are generated. height takes precedence over tan if
-                        both have a non-zero value. The default value of tan is 0.0.
+                        height. The tangent `tan` of the roof pitch angle can be supplied for that case. If both `height`
+                        and `tan` are equal to zero, flat faces are generated. `height` takes precedence over `tan` if
+                        both have a non-zero value. The default value of `tan` is 0.0.
 
-    faces:              An already existing Python list of faces. Everey face in this list is itself a list of
+    faces:              An already existing Python list of faces. Every face in this list is itself a list of
                         indices of the face-vertices in the verts list. If this argument is None (its default value),
                         a new list with the new faces created by the straight skeleton is created and returned by
                         polygonize(), else faces is extended by the new list.
 
     unitVectors:        A Python list of unit vectors along the polygon edges (including holes if they are present).
-                        These vectors are of type mathutils.Vector with three dimensions. The direction of the vectors
+                        These vectors are of type `mathutils.Vector` with three dimensions. The direction of the vectors
                         corresponds to order of the vertices in the polygon and its holes. The order of the unit
                         vectors in the unitVectors list corresponds to the order of vertices in the input Python list
                         verts.
 
-                        The list unitVectors (if given) gets used inside polygonize() function instead of calculating
+                        The list `unitVectors` (if given) gets used inside polygonize() function instead of calculating
                         it once more. If this argument is None (its default value), the unit vectors get calculated
                         inside polygonize().
 
     Output:
     ------
-    verts:              The list of the vertices verts gets extended at its end by the vertices of the straight skeleton.
+    verts:              The list of the vertices `verts` gets extended at its end by the vertices of the straight skeleton.
 
-    return:             A list of the faces created by the straight skeleton. Everey face in this list is a list of
+    return:             A list of the faces created by the straight skeleton. Every face in this list is a list of
                         indices of the face-vertices in the verts list. The order of vertices of the faces is
-                        counterclockwise, as the order of vertices in the input Python list verts. The first edge of
-                        a face is always an edge of the polygon or its holes.    
+                        counterclockwise, as the order of vertices in the input Python list `verts`. The first edge of
+                        a face is always an edge of the polygon or its holes.
 
                         If a list of faces has been given in the argument faces, it gets extended at its end by the
-                        new list.              
+                        new list.
     """
     # assume that all vertices of polygon and holes have the same z-value
     zBase = verts[firstVertIndex][2]
 
     # compute center of gravity of polygon
-    center = mathutils.Vector((0.0,0.0,0.0))
+    center = mathutils.Vector((0.0, 0.0, 0.0))
     for i in range(firstVertIndex,firstVertIndex+numVerts):
         center += verts[i]
     center /= numVerts

--- a/demo.py
+++ b/demo.py
@@ -69,7 +69,7 @@ def create_roof(pitch, ax):
     for face in faces:
         for edge in zip(face, face[1:] + face[:1]):
             p1, p2 = VERTS[edge[0]], VERTS[edge[1]]
-            ax.plot([p1.x,p2.x], [p1.y,p2.y], [p1.z,p2.z], 'k')
+            ax.plot([p1.x, p2.x], [p1.y, p2.y], [p1.z, p2.z], 'k')
 
     ax.axis('equal')
     ax.set_zlim(0, 30)

--- a/demo.py
+++ b/demo.py
@@ -6,55 +6,97 @@ where the library mathutils is installed as standalone library.
 
 Use 'pip install mathutils'
 """
-import matplotlib.pyplot as plt
+import math
 import mathutils
+import matplotlib.pyplot as plt
+
 from bpypolyskel import bpypolyskel
+from matplotlib.widgets import Slider
 
-def runDemo():
-	#Define vertices of a polygon and a hole
-	verts = [
-		# polygon contour in counterclockwise order, seen from top, 
-		# the polygon is on the left of this contour
-		mathutils.Vector((0, 0, 0)),
-		mathutils.Vector((10, 0, 0)),
-		mathutils.Vector((10, 5, 0)),
-		mathutils.Vector((45, 5, 0)),
-		mathutils.Vector((45, 20, 0)),
-		mathutils.Vector((10, 20, 0)),
-		mathutils.Vector((10, 25, 0)),
-		mathutils.Vector((0, 25, 0)),
-		# hole contour in clockwise order, seen from top, 
-		# the polygon is on the left of this contour
-		mathutils.Vector((5, 16, 0)),
-		mathutils.Vector((35, 16, 0)),
-		mathutils.Vector((35, 9, 0)),
-		mathutils.Vector((5, 9, 0))
-	]
 
-	# Define indices and lengths of polygon and hole
-	firstVertIndex = 0
-	numVerts = 8
-	holesInfo = [
-		(8,4)
-	]
+# Define vertices of a polygon and a hole.
+_COORDS = [
+    # Polygon contour in counterclockwise order, seen from top.
+    # The polygon is on the left of this contour.
+    [0, 0, 0],
+    [10, 0, 0],
+    [10, 5, 0],
+    [45, 5, 0],
+    [45, 20, 0],
+    [10, 20, 0],
+    [10, 25, 0],
+    [0, 25, 0],
+    # Hole contour in clockwise order, seen from top.
+    # The polygon is on the left of this contour.
+    [5, 16, 0],
+    [35, 16, 0],
+    [35, 9, 0],
+    [5, 9, 0],
+]
 
-	# We let polygonize() compute the unit vectors
-	# and have no faces yet
-	unitVectors = None
-	faces = None
+# Convert the coordinates to 'mathutils.Vector' objects.
+VERTS = [mathutils.Vector(coords) for coords in _COORDS]
 
-	faces = bpypolyskel.polygonize(verts, firstVertIndex, numVerts, holesInfo, 0.0, 0.5, faces, unitVectors)
+# Define indices and lengths of polygon and hole.
+FIRST_VERTEX_INDEX = 0
+NUM_VERTS = 8
+HOLES_INFO = [(8, 4)]
 
-	# plot the hipped roof in 3D
-	fig = plt.figure()
-	ax = fig.gca(projection='3d')
-	for face in faces:
-		for edge in zip(face, face[1:] + face[:1]):
-			p1 = verts[edge[0]]
-			p2 = verts[edge[1]]
-			ax.plot([p1.x,p2.x],[p1.y,p2.y],[p1.z,p2.z],'k')
-	plt.show()
+# We let polygonize() compute the unit vectors and have no faces yet.
+FACES, UNIT_VECTORS = None, None
+
+# Pitch values.
+MIN_PITCH = 0.0
+MAX_PITCH = 80.0
+DEFAULT_PITCH = 30.0
+
+
+def create_roof(pitch, ax):
+    ax.clear()
+
+    faces = bpypolyskel.polygonize(
+        VERTS,
+        FIRST_VERTEX_INDEX,
+        NUM_VERTS,
+        HOLES_INFO,
+        0.0,
+        math.tan(pitch * math.pi / 180),
+        FACES,
+        UNIT_VECTORS,
+    )
+
+    # Plot the hipped roof in 3D.
+    for face in faces:
+        for edge in zip(face, face[1:] + face[:1]):
+            p1, p2 = VERTS[edge[0]], VERTS[edge[1]]
+            ax.plot([p1.x,p2.x], [p1.y,p2.y], [p1.z,p2.z], 'k')
+
+    ax.axis('equal')
+    ax.set_zlim(0, 30)
+
+
+def run_demo():
+    fig = plt.figure('Roof Demo')
+    ax = fig.add_subplot(projection='3d')
+
+    # Display the roof using the default pitch.
+    create_roof(DEFAULT_PITCH, ax)
+
+    # Add a vertical slider to control the pitch.
+    pitch_slider = Slider(
+        ax=fig.add_axes([0.9, 0.2, 0.02, 0.6]),
+        label="Roof pitch\n(degrees)",
+        valmin=MIN_PITCH,
+        valmax=MAX_PITCH,
+        valinit=DEFAULT_PITCH,
+        valstep=1.0,
+        orientation="vertical"
+    )
+    pitch_slider.on_changed(lambda pitch: create_roof(pitch, ax))
+
+    plt.show()
+
 
 if __name__ == "__main__":
-    # execute only if run as a script
-    runDemo()
+    # Execute only if run as a script.
+    run_demo()


### PR DESCRIPTION
I'm proposing the addition of a slider to control the roof pitch while also updating the code with support for the latest `matplotlib` library. When running the old version of the code I was getting the following error: 

```
FigureBase.gca() got an unexpected keyword argument 'projection'
```

This now works fine under `matplotlib 3.7.1`.

![roof demo](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2RjMWVhOGQxMmFlZTE4NmU4OTY2MTQwM2M2MjdmOGMxZmRiN2Q4NyZjdD1n/lUCdHRfem9fudxP8YX/giphy.gif)


@vvoovv @polarkernel