### PR TITLE
Add pyproject.toml for wheel packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "bpypolyskel"
+version = "0.0.1"
+description = "Straight skeleton library for hipped roof generation."
+readme = "README.md"
+license = "GPL-3.0-only"
+license-files = ["LICENSE"]
+requires-python = ">=3.10"
+
+[tool.setuptools]
+packages = ["bpypolyskel"]


### PR DESCRIPTION
Hi! Added `pyproject.toml` to make `bpypolyskel` easily buildsable as a wheel.
Nowadays Blender extensions pack dependencies as wheels. we were building `bpypolyskel` as one in https://bonsaibim.org/, but wanted to upstream it to make wheel buildable as `pip wheel "git+https://github.com/prochitecture/bpypolyskel` or installed locally with `pip install "git+https://github.com/prochitecture/bpypolyskel"` for tooltips in IDE.

@vvoovv @polarkernel can you please take a look?